### PR TITLE
implement from_std_tcp_stream

### DIFF
--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -256,7 +256,7 @@ impl Drop for SocketStreamInner {
 }
 
 impl SocketStreamInner {
-    fn new(reactor: Rc<RefCell<Reactor>>, stream: ::std::net::TcpStream)
+    pub fn new(reactor: Rc<RefCell<Reactor>>, stream: ::std::net::TcpStream)
            -> Result<SocketStreamInner, ::std::io::Error>
     {
         let mut read_overlapped = Box::new(::miow::Overlapped::zero());


### PR DESCRIPTION
Based on our discussion in #3, this adds additional documentation to `wrap_raw_socket_descriptor` and also provides a safe method `into_socket_stream`.

A question that remains for me, and which maybe you can answer, is what happens to the descriptor if `wrap_raw_socket_descriptor` returns an `Err`? Is it still going to be closed for us, or does it have to be closed manually?
